### PR TITLE
feat: 增加 stop 处理

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -175,7 +175,6 @@ so.state = function(name, config){
 }
 
 so.stop = function (options, callback) {
-  console.error('current component:', this.current.component, 'this component', this.component);
     var component = this.current && this.current.component;
     if (component) {
       _.proxyMethod(component.$root, 'destroy', options);

--- a/src/client.js
+++ b/src/client.js
@@ -171,18 +171,18 @@ so.state = function(name, config){
 
   }
 
-  so.stop = function (options, callback) {
-    console.error('current component:', this.current.component, 'this component', this.component);
-      var component = this.current && this.current.component;
-      if (component) {
-        _.proxyMethod(component.$root, 'destroy', options);
-      }
-
-      return oldStop.call(this, options, callback);
-  };
-
   return oldStateFn.call(this, name, config)
 }
+
+so.stop = function (options, callback) {
+  console.error('current component:', this.current.component, 'this component', this.component);
+    var component = this.current && this.current.component;
+    if (component) {
+      _.proxyMethod(component.$root, 'destroy', options);
+    }
+
+    return oldStop.call(this, options, callback);
+};
 
 
 

--- a/src/client.js
+++ b/src/client.js
@@ -23,7 +23,7 @@ so.start = function(options, callback){
   var ssr = options.ssr;
   var view = options.view;
   this.view = view;
-  // prevent default stateman autoLink feature 
+  // prevent default stateman autoLink feature
   options.autolink = false;
   if(ssr) {
     // wont fix .
@@ -57,23 +57,23 @@ so.state = function(name, config){
 
     // 不代理canEnter事件, 因为此时component还不存在
     // mount (if not installed, install first)
-    
+
     // 1. .Null => a.b.c
-    // canEnter a  -> canEnter a.b -> canEnter a.b.c -> 
-    //  -> install a ->enter a -> mount a 
-    //  -> install a.b -> enter a.b -> mount a.b 
+    // canEnter a  -> canEnter a.b -> canEnter a.b.c ->
+    //  -> install a ->enter a -> mount a
+    //  -> install a.b -> enter a.b -> mount a.b
     //  -> install a.b.c -> enter a.b.c -> mount a.b.c
 
 
     // 2. update a.b.c
-    // -> install a -> mount a 
-    // -> install a.b -> mount a.b 
+    // -> install a -> mount a
+    // -> install a.b -> mount a.b
     // -> install a.b.c -> mount a.b.c
 
     // 3. a.b.c -> a.b.d
-    // canLeave c -> canEnter d -> leave c 
-    //  -> install a -> mount a -> 
-    //  -> install b -> mount b -> 
+    // canLeave c -> canEnter d -> leave c
+    //  -> install a -> mount a ->
+    //  -> install b -> mount b ->
     //  -> install d -> enter d -> mount d
 
     function install( option , isEnter){
@@ -167,9 +167,19 @@ so.state = function(name, config){
       }
     }
     _.extend(config, oldConfig, true)
-    
+
   }
-  return oldStateFn.call(this, name, config)    
+
+  so.stop = function (options, callback) {
+      var component = this.current && this.current.component;
+      if (component) {
+        _.proxyMethod(component.$root, 'destroy', options);
+      }
+
+      return oldStop.call(this, options, callback);
+  };
+
+  return oldStateFn.call(this, name, config)
 }
 
 

--- a/src/client.js
+++ b/src/client.js
@@ -15,6 +15,7 @@ var so = Restate.prototype;
 
 var oldStateFn = so.state;
 var oldStart = so.start;
+var oldStop = so.stop;
 
 
 so.start = function(options, callback){
@@ -171,6 +172,7 @@ so.state = function(name, config){
   }
 
   so.stop = function (options, callback) {
+    console.error('current component:', this.current.component, 'this component', this.component);
       var component = this.current && this.current.component;
       if (component) {
         _.proxyMethod(component.$root, 'destroy', options);


### PR DESCRIPTION
目前未重载的 stop 只处理了 `this.history.stop();`，未对组件进行卸载，这在单个 Regular 应用里是没问题的。但是目前用了微前端的方案，从 Regular 应用切到 React 未对组件进行卸载，可能会导致一些全局事件被多次注册。故补充了下方法，供以主动调用。